### PR TITLE
Fixed bug. Creating  MultiPoint.php (containing single point)

### DIFF
--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -2,6 +2,26 @@
 
 class MultiPoint extends PointCollection implements GeometryInterface, \JsonSerializable
 {
+    /**
+     * @param Point[] $points
+     */
+    public function __construct(array $points)
+    {
+        if (count($points) < 1) {
+            throw new InvalidArgumentException('$points must contain at least one entry');
+        }
+
+        $validated = array_filter($points, function ($value) {
+            return $value instanceof Point;
+        });
+
+        if (count($points) !== count($validated)) {
+            throw new InvalidArgumentException('$points must be an array of Points');
+        }
+        $this->points = $points;
+    }
+    
+    
     public function toWKT()
     {
         return sprintf('MULTIPOINT(%s)', (string)$this);


### PR DESCRIPTION
Fixed bug when creating multipoint, contain single point

example:

$collection = [new Point(0, 0)];
$multipoint = new MultiPoint($collection);
