### PR TITLE
Pass by reference bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         "illuminate/database": "^5.2",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0",
-        "phoenixgao/laravel-postgres-extended-schema": "^0.14.0"
+        "phoenixgao/laravel-postgres-extended-schema": "~0.15"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mockery/mockery": "0.9.*",
-        "satooshi/php-coveralls": "~0.6",
-        "codeclimate/php-test-reporter": "dev-master",
+        "satooshi/php-coveralls": "~1.0",
+        "codeclimate/php-test-reporter": "~0.3",
         "illuminate/pagination": "~5.0"
     },
     "autoload": {

--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -23,13 +23,13 @@ trait PostgisTrait
 
     protected function performInsert(EloquentBuilder $query, array $options = [])
     {
-        foreach ($this->attributes as $key => &$value) {
+        foreach ($this->attributes as $key => $value) {
             if ($value instanceof GeometryInterface && ! $value instanceof GeometryCollection) {
                 $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
-                $value = $this->getConnection()->raw(sprintf("ST_GeogFromText('%s')", $value->toWKT()));
+                $this->attributes[$key] = $this->getConnection()->raw(sprintf("ST_GeogFromText('%s')", $value->toWKT()));
             }  else if ($value instanceof GeometryInterface && $value instanceof GeometryCollection) {
                 $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
-                $value = $this->getConnection()->raw(sprintf("ST_GeomFromText('%s', 4326)", $value->toWKT()));
+                $this->attributes[$key] = $this->getConnection()->raw(sprintf("ST_GeomFromText('%s', 4326)", $value->toWKT()));
             }
         }
 


### PR DESCRIPTION
Nasty little bug here, in that ```$value``` is a referenced variable but it is then re-used again in another foreach loop further down.

Easy solution is avoid the risky pass-by-reference altogether as ```$this->attributes[$key] = ...``` will suffice for updating any existing values on the model.

This [stack overflow question](http://stackoverflow.com/questions/3307409/php-pass-by-reference-in-foreach) sums up the exact problem quite nicely.