### PR TITLE
Fixed version bosnadev/database to 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.5",
         "illuminate/database": "~5.1.0",
-        "bosnadev/database": "~0.1",
+        "bosnadev/database": "0.12",
         "geo-io/wkb-parser": "~1.0",
         "jmikola/geojson": "~1.0"
     },


### PR DESCRIPTION
bosnadev/database 0.13 >= breaks Laravel 5.1 compatibility.
https://github.com/Bosnadev/Database/commit/ea6f54f232625923782c3fa9e8545b211c56782c