### PR TITLE
PostgresBuilder Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+  - nightly
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,12 @@
         "illuminate/database": "^5.2",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0",
-        "phoenixgao/laravel-postgres-extended-schema": "^0.14.0"
+        "phoenixgao/laravel-postgres-extended-schema": "^0.15.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mockery/mockery": "0.9.*",
-        "satooshi/php-coveralls": "~0.6",
-        "codeclimate/php-test-reporter": "dev-master",
+        "codeclimate/php-test-reporter": "^0.3.2",
         "illuminate/pagination": "~5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         "illuminate/database": "^5.2",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0",
-        "phoenixgao/laravel-postgres-extended-schema": "^0.15.0"
+        "phoenixgao/laravel-postgres-extended-schema": "~0.15"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mockery/mockery": "0.9.*",
-        "codeclimate/php-test-reporter": "^0.3.2",
+        "codeclimate/php-test-reporter": "~0.3",
         "illuminate/pagination": "~5.0"
     },
     "autoload": {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -2,7 +2,7 @@
 
 use Closure;
 
-class Builder extends \Bosnadev\Database\Schema\Builder
+class Builder extends \Illuminate\Database\Schema\PostgresBuilder
 {
     /**
      * Create a new command set with a Closure.


### PR DESCRIPTION
This fixes the Builder to extend Laravel’s new PostgresBuilder class, and should therefore fix issue#48. Also makes small changes to `composer.json` and `.travis.yml`.

Specifically make it so `composer install` doesn’t can resolve the dependencies by using a tagged release of `codeclimate/php-test-reporter`, and letting composer install `satooshi/php-coveralls` as a dependency for the code climate package. Also bumps a the minor version for `phoenixgao/laravel-postgres-extended-schema`.

As for TravisCI, we now test against php7 and nightly.