### PR TITLE
Small tidy of composer.json and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+  - nightly
+matrix:
+  allow_failures:
+    - nightly
 
 install:
-  - composer install
+  - travis_retry composer install
 
 before_script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mockery/mockery": "0.9.*",
-        "satooshi/php-coveralls": "~1.0",
         "codeclimate/php-test-reporter": "~0.3",
         "illuminate/pagination": "~5.0"
     },


### PR DESCRIPTION
`satooshi/php-coveralls` is already a dependency of `codeclimate/php-test-reporter`, our travis config will now test against more versions of PHP