### PR TITLE
Fix bug that causes other packages not to work

### DIFF
--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -52,7 +52,7 @@ trait PostgisTrait
             }
         }
 
-        parent::setRawAttributes($attributes, $sync);
+        return parent::setRawAttributes($attributes, $sync);
     }
 
     public function getPostgisFields()


### PR DESCRIPTION
The Eloquent Model's `setRawAttributes` method returns `this`, which allows it to be chained with other methods. This package currently does not return anything from the overriden method, which causes other packages (such as [spatie/laravel-activitylog](https://github.com/spatie/laravel-activitylog) to break. This fix returns the result of `parent::setRawAttributes` to resolve this issue.