### PR TITLE
Add Geometry and Custom SRID

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,48 @@ class Location extends Model
     ];
 
     protected $postgisFields = [
-        'location',
-        'polygon',
+        'location' => [
+            'geomtype' => 'geography',
+            'srid' => 4326
+        ],
+        'location2' => [
+            'geomtype' => 'geography',
+            'srid' => 4326
+        ],
+        'location3' => [
+            'geomtype' => 'geometry',
+            'srid' => 27700
+        ],
+        'polygon' => [
+            'geomtype' => 'geography',
+            'srid' => 4326
+        ],
+        'polygon2' => [
+            'geomtype' => 'geometry',
+            'srid' => 27700
+        ]
     ];
 
 }
+
+$linestring = new LineString(
+    [
+        new Point(0, 0),
+        new Point(0, 1),
+        new Point(1, 1),
+        new Point(1, 0),
+        new Point(0, 0)
+    ]
+);
 
 $location1 = new Location();
 $location1->name = 'Googleplex';
 $location1->address = '1600 Amphitheatre Pkwy Mountain View, CA 94043';
 $location1->location = new Point(37.422009, -122.084047);
+$location1->location2 = new Point(37.422009, -122.084047);
+$location1->location3 = new Point(37.422009, -122.084047);
+$location1->polygon = new Polygon([$linestring]);
+$location1->polygon2 = new Polygon([$linestring]);
 $location1->save();
 
 $location2 = Location::first();

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Laravel postgis extension
 
  * Work with geometry classes instead of arrays. (`$myModel->myPoint = new Point(1,2)`)
  * Adds helpers in migrations. (`$table->polygon('myColumn')`)
- 
+
 ### Future plans
- 
+
  * Geometry functions on the geometry classes (contains(), equals(), distance(), etc… (HELP!))
 
 ## Versions
@@ -22,7 +22,7 @@ Laravel postgis extension
 
 ## Installation
 
-    composer require phaza/laravel-postgis 
+    composer require phaza/laravel-postgis
 
 Next add the DatabaseServiceProvider to your `config/app.php` file.
 
@@ -70,8 +70,11 @@ class CreateLocationsTable extends Migration {
             $table->increments('id');
             $table->string('name');
             $table->string('address')->unique();
-            $table->point('location');
-            $table->polygon('polygon');
+            $table->point('location'); // GEOGRAPHY POINT column with SRID of 4326 (these are the default values).
+            $table->point('location2', 'GEOGRAPHY', 4326); // GEOGRAPHY POINT column with SRID of 4326 with optional parameters.
+            $table->point('location3', 'GEOMETRY', 27700); // GEOMETRY column with SRID of 27700.
+            $table->polygon('polygon'); // GEOGRAPHY POLYGON column with SRID of 4326.
+            $table->polygon('polygon2', 'GEOMETRY', 27700); // GEOMETRY POLYGON column with SRID of 27700.
             $table->timestamps();
         });
     }
@@ -143,7 +146,7 @@ $location2->location instanceof Point // true
 ```
 
 Available geometry classes:
- 
+
  * Point
  * MultiPoint
  * LineString

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ other methods:
 All models which are to be PostGis enabled **must** use the *PostgisTrait*.
 
 You must also define an array called `$postgisFields` which defines
-what attributes/columns on your model are to be considered geometry objects.
+what attributes/columns on your model are to be considered geometry objects. By default, all attributes are of type `geography`. If you want to use `geometry` with a custom SRID, you have to define an array called `$postgisTypes`. The keys of this assoc array must match the entries in `$postgisFields` (all missing keys default to `geography`), the values are assoc arrays, too. They must have two keys: `geomtype` which is either `geography` or `geometry` and `srid` which is the desired SRID. **Note**: Custom SRID is only supported for `geometry`, not `geography`.
 
 ```PHP
 use Illuminate\Database\Eloquent\Model;
@@ -129,6 +129,14 @@ class Location extends Model
     ];
 
     protected $postgisFields = [
+        'location',
+        'location2',
+        'location3',
+        'polygon',
+        'polygon2'
+    ];
+    
+    protected $postgisTypes = [
         'location' => [
             'geomtype' => 'geography',
             'srid' => 4326
@@ -149,8 +157,7 @@ class Location extends Model
             'geomtype' => 'geometry',
             'srid' => 27700
         ]
-    ];
-
+    ]
 }
 
 $linestring = new LineString(

--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -3,6 +3,8 @@
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Arr;
 use Phaza\LaravelPostgis\Exceptions\PostgisFieldsNotDefinedException;
+use Phaza\LaravelPostgis\Exceptions\PostgisTypesMalformedException;
+use Phaza\LaravelPostgis\Exceptions\UnsupportedGeomtypeException;
 use Phaza\LaravelPostgis\Geometries\Geometry;
 use Phaza\LaravelPostgis\Geometries\GeometryInterface;
 use Phaza\LaravelPostgis\Schema\Grammars\PostgisGrammar;
@@ -68,8 +70,16 @@ trait PostgisTrait
 
     public function getPostgisType($key)
     {
+        $default = [
+            'geomtype' => 'geography',
+            'srid' => 4326
+        ];
+
         if (property_exists($this, 'postgisTypes')) {
             if (Arr::isAssoc($this->postgisTypes)) {
+                if(!array_key_exists($key, $this->postgisTypes)) {
+                    return $default;
+                }
                 $column = $this->postgisTypes[$key];
                 if (isset($column['geomtype']) && in_array(strtoupper($column['geomtype']), PostgisGrammar::$allowed_geom_types)) {
                     return $column;
@@ -82,10 +92,7 @@ trait PostgisTrait
         }
 
         // Return default geography if postgisTypes does not exist (for backward compatibility)
-        return [
-            'geomtype' => 'geography',
-            'srid' => 4326
-        ];
+        return $default;
     }
 
     public function getPostgisFields()

--- a/src/Exceptions/PostgisTypesMalformedException.php
+++ b/src/Exceptions/PostgisTypesMalformedException.php
@@ -1,0 +1,7 @@
+<?php namespace Phaza\LaravelPostgis\Exceptions;
+
+use RuntimeException;
+
+class PostgisTypesMalformedException extends RuntimeException
+{
+}

--- a/src/Exceptions/UnsupportedGeomtypeException.php
+++ b/src/Exceptions/UnsupportedGeomtypeException.php
@@ -1,0 +1,7 @@
+<?php namespace Phaza\LaravelPostgis\Exceptions;
+
+use RuntimeException;
+
+class UnsupportedGeomtypeException extends RuntimeException
+{
+}

--- a/src/PostgisConnection.php
+++ b/src/PostgisConnection.php
@@ -8,6 +8,7 @@ class PostgisConnection extends \Bosnadev\Database\PostgresConnection
 
         // Prevent geography type fields from throwing a 'type not found' error.
         $this->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('geography', 'string');
+        $this->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('geometry', 'string');
     }
 
     /**

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -8,9 +8,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function point($column)
+    public function point($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('point', $column);
+        return $this->addColumn('point', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -19,9 +19,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function multipoint($column)
+    public function multipoint($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('multipoint', $column);
+        return $this->addColumn('multipoint', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -30,9 +30,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function polygon($column)
+    public function polygon($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('polygon', $column);
+        return $this->addColumn('polygon', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -41,9 +41,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function multipolygon($column)
+    public function multipolygon($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('multipolygon', $column);
+        return $this->addColumn('multipolygon', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -52,9 +52,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function linestring($column)
+    public function linestring($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('linestring', $column);
+        return $this->addColumn('linestring', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -63,9 +63,9 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param      $column
      * @return \Illuminate\Support\Fluent
      */
-    public function multilinestring($column)
+    public function multilinestring($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('multilinestring', $column);
+        return $this->addColumn('multilinestring', $column, compact('geomtype', 'srid'));
     }
 
     /**
@@ -74,9 +74,20 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * @param   string  $column
      * @return \Illuminate\Support\Fluent
      */
-    public function geography($column)
+    public function geography($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
     {
-        return $this->addColumn('geography', $column);
+        return $this->addColumn('geography', $column, compact('geomtype', 'srid'));
+    }
+
+    /**
+     * Add a geometry column on the table
+     *
+     * @param   string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function geometry($column, $geomtype = 'GEOGRAPHY', $srid = '4326')
+    {
+        return $this->addColumn('geometry', $column, compact('geomtype', 'srid'));
     }
 
     /**

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -18,7 +18,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePoint(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(POINT, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
@@ -33,7 +33,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipoint(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTIPOINT, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
@@ -48,7 +48,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePolygon(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(POLYGON, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
@@ -63,7 +63,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipolygon(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTIPOLYGON, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
@@ -78,7 +78,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeLinestring(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(LINESTRING, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
@@ -93,7 +93,7 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultilinestring(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTILINESTRING, ' . $column->srid . ')';
         } else {
             throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Fluent;
 use Phaza\LaravelPostgis\Schema\Blueprint;
+use Phaza\LaravelPostgis\Exceptions\UnsupportedGeomtypeException;
 use Bosnadev\Database\Schema\Grammars\PostgresGrammar;
 
 class PostgisGrammar extends PostgresGrammar
@@ -20,7 +21,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(POINT, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 
@@ -35,7 +36,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTIPOINT, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 
@@ -50,7 +51,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(POLYGON, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 
@@ -65,7 +66,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTIPOLYGON, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 
@@ -80,7 +81,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(LINESTRING, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 
@@ -95,7 +96,7 @@ class PostgisGrammar extends PostgresGrammar
         if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
             return strtoupper($column->geomtype) . '(MULTILINESTRING, ' . $column->srid . ')';
         } else {
-            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
         }
     }
 

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -8,7 +8,7 @@ use Bosnadev\Database\Schema\Grammars\PostgresGrammar;
 class PostgisGrammar extends PostgresGrammar
 {
 
-    private $allowed_geom_types = ['GEOMETRY', 'GEOGRAPHY'];
+    public static $allowed_geom_types = ['GEOGRAPHY', 'GEOMETRY'];
 
     /**
      * Adds a statement to add a point geometry column

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -6,6 +6,9 @@ use Bosnadev\Database\Schema\Grammars\PostgresGrammar;
 
 class PostgisGrammar extends PostgresGrammar
 {
+
+    private $allowed_geom_types = ['GEOMETRY', 'GEOGRAPHY'];
+
     /**
      * Adds a statement to add a point geometry column
      *
@@ -14,7 +17,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePoint(Fluent $column)
     {
-        return 'GEOGRAPHY(POINT, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(POINT, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -25,7 +32,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipoint(Fluent $column)
     {
-        return 'GEOGRAPHY(MULTIPOINT, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(MULTIPOINT, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -36,7 +47,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePolygon(Fluent $column)
     {
-        return 'GEOGRAPHY(POLYGON, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(POLYGON, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -47,7 +62,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipolygon(Fluent $column)
     {
-        return 'GEOGRAPHY(MULTIPOLYGON, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(MULTIPOLYGON, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -58,7 +77,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeLinestring(Fluent $column)
     {
-        return 'GEOGRAPHY(LINESTRING, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(LINESTRING, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -69,7 +92,11 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultilinestring(Fluent $column)
     {
-        return 'GEOGRAPHY(MULTILINESTRING, 4326)';
+        if ((in_array(strtoupper($column->geomtype), $this->allowed_geom_types)) && (is_int((int) $column->srid))) {
+            return strtoupper($column->geomtype) . '(MULTILINESTRING, ' . $column->srid . ')';
+        } else {
+            return dd('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)'); // TODO exc
+        }
     }
 
     /**
@@ -81,6 +108,17 @@ class PostgisGrammar extends PostgresGrammar
     public function typeGeography(Fluent $column)
     {
         return 'GEOGRAPHY';
+    }
+
+    /**
+     * Adds a statement to add a geometry column
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeGeometry(Fluent $column)
+    {
+        return 'GEOMETRY';
     }
 
     /**

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -18,10 +18,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePoint(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
-            return strtoupper($column->geomtype) . '(POINT, ' . $column->srid . ')';
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
+            return $type . '(POINT, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -33,10 +37,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipoint(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
             return strtoupper($column->geomtype) . '(MULTIPOINT, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -48,10 +56,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typePolygon(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
             return strtoupper($column->geomtype) . '(POLYGON, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -63,10 +75,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultipolygon(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
             return strtoupper($column->geomtype) . '(MULTIPOLYGON, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -78,10 +94,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeLinestring(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
             return strtoupper($column->geomtype) . '(LINESTRING, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -93,10 +113,14 @@ class PostgisGrammar extends PostgresGrammar
      */
     public function typeMultilinestring(Fluent $column)
     {
-        if ((in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types)) && (is_int((int) $column->srid))) {
+        $type = strtoupper($column->geomtype);
+        if ($this->isValid($column)) {
+            if ($type == 'GEOGRAPHY' && $column->srid != 4326) {
+                throw new UnsupportedGeomtypeException('Error with validation of srid! SRID of GEOGRAPHY must be 4326)');
+            }
             return strtoupper($column->geomtype) . '(MULTILINESTRING, ' . $column->srid . ')';
         } else {
-            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid! (If geom type is GEOGRAPHY then the SRID must be 4326)');
+            throw new UnsupportedGeomtypeException('Error with validation of geom type or srid!');
         }
     }
 
@@ -179,5 +203,15 @@ class PostgisGrammar extends PostgresGrammar
             $dimensions,
             $typmod
         );
+    }
+
+    /**
+     * Checks if the given $column is a valid geometry type
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return boolean
+     */
+    protected function isValid($column) {
+        return in_array(strtoupper($column->geomtype), PostgisGrammar::$allowed_geom_types) && is_int((int) $column->srid);
     }
 }

--- a/tests/Eloquent/PostgisTraitTest.php
+++ b/tests/Eloquent/PostgisTraitTest.php
@@ -37,6 +37,14 @@ class PostgisTraitTest extends BaseTestCase
         $this->assertContains("public.ST_GeogFromText('POINT(2 1)')", $this->queries[0]);
     }
 
+    public function testInsertPointGeometryHasCorrectSql()
+    {
+        $this->model->point2 = new Point(1, 2);
+        $this->model->save();
+
+        $this->assertContains("public.ST_GeomFromText('POINT(2 1)', '27700')", $this->queries[0]);
+    }
+
     public function testUpdatePointHasCorrectSql()
     {
         $this->model->exists = true;
@@ -52,7 +60,15 @@ class TestModel extends Model
     use PostgisTrait;
 
     protected $postgisFields = [
-        'point' => Point::class
+        'point' => Point::class,
+        'point2' => Polygon::class,
+    ];
+
+    protected $postgisTypes = [
+        'point2' => [
+            'geomtype' => 'geometry',
+            'srid' => 27700
+        ]
     ];
 
 

--- a/tests/Eloquent/PostgisTraitTest.php
+++ b/tests/Eloquent/PostgisTraitTest.php
@@ -102,6 +102,7 @@ class TestPDO extends PDO
         $this->queries[] = $statement;
 
         $stmt = m::mock('PDOStatement');
+        $stmt->shouldReceive('setFetchMode');
         $stmt->shouldReceive('bindValue')->zeroOrMoreTimes();
         $stmt->shouldReceive('execute');
         $stmt->shouldReceive('fetchAll')->andReturn([['id' => 1, 'point' => 'POINT(1 2)']]);

--- a/tests/Schema/Grammars/PostgisGrammarTest.php
+++ b/tests/Schema/Grammars/PostgisGrammarTest.php
@@ -17,6 +17,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOGRAPHY(POINT, 4326)', $statements[0]);
     }
 
+    public function testAddingPointGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->point('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(POINT, 27700)', $statements[0]);
+    }
+
     public function testAddingLinestring()
     {
         $blueprint = new Blueprint('test');
@@ -25,6 +34,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOGRAPHY(LINESTRING, 4326)', $statements[0]);
+    }
+
+    public function testAddingLinestringGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->linestring('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(LINESTRING, 27700)', $statements[0]);
     }
 
     public function testAddingPolygon()
@@ -37,6 +55,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOGRAPHY(POLYGON, 4326)', $statements[0]);
     }
 
+    public function testAddingPolygonGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->polygon('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(POLYGON, 27700)', $statements[0]);
+    }
+
     public function testAddingMultipoint()
     {
         $blueprint = new Blueprint('test');
@@ -45,6 +72,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOGRAPHY(MULTIPOINT, 4326)', $statements[0]);
+    }
+
+    public function testAddingMultipointGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->multipoint('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(MULTIPOINT, 27700)', $statements[0]);
     }
 
     public function testAddingMultiLinestring()
@@ -57,6 +93,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOGRAPHY(MULTILINESTRING, 4326)', $statements[0]);
     }
 
+    public function testAddingMultiLinestringGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->multilinestring('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(MULTILINESTRING, 27700)', $statements[0]);
+    }
+
     public function testAddingMultiPolygon()
     {
         $blueprint = new Blueprint('test');
@@ -67,6 +112,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOGRAPHY(MULTIPOLYGON, 4326)', $statements[0]);
     }
 
+    public function testAddingMultiPolygonGeom()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->multipolygon('foo', 'GEOMETRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY(MULTIPOLYGON, 27700)', $statements[0]);
+    }
+
     public function testAddingGeography()
     {
         $blueprint = new Blueprint('test');
@@ -75,6 +129,15 @@ class PostgisGrammarBaseTest extends BaseTestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOGRAPHY', $statements[0]);
+    }
+
+    public function testAddingGeometry()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->geometry('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOMETRY', $statements[0]);
     }
 
     public function testAddingGeometryCollection()

--- a/tests/Schema/Grammars/PostgisGrammarTest.php
+++ b/tests/Schema/Grammars/PostgisGrammarTest.php
@@ -4,6 +4,8 @@ use Illuminate\Database\Connection;
 use Phaza\LaravelPostgis\PostgisConnection;
 use Phaza\LaravelPostgis\Schema\Blueprint;
 use Phaza\LaravelPostgis\Schema\Grammars\PostgisGrammar;
+use Phaza\LaravelPostgis\Exceptions\PostgisTypesMalformedException;
+use Phaza\LaravelPostgis\Exceptions\UnsupportedGeomtypeException;
 
 class PostgisGrammarBaseTest extends BaseTestCase
 {
@@ -26,6 +28,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOMETRY(POINT, 27700)', $statements[0]);
     }
 
+    public function testAddingPointWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->point('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingPointUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->point('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
     public function testAddingLinestring()
     {
         $blueprint = new Blueprint('test');
@@ -43,6 +63,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOMETRY(LINESTRING, 27700)', $statements[0]);
+    }
+
+    public function testAddingLinestringWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->linestring('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingLinestringUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->linestring('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
     }
 
     public function testAddingPolygon()
@@ -64,6 +102,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOMETRY(POLYGON, 27700)', $statements[0]);
     }
 
+    public function testAddingPolygonWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->polygon('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingPolygonUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->polygon('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
     public function testAddingMultipoint()
     {
         $blueprint = new Blueprint('test');
@@ -81,6 +137,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOMETRY(MULTIPOINT, 27700)', $statements[0]);
+    }
+
+    public function testAddingMultiPointWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multipoint('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingMultiPointUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multipoint('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
     }
 
     public function testAddingMultiLinestring()
@@ -102,6 +176,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOMETRY(MULTILINESTRING, 27700)', $statements[0]);
     }
 
+    public function testAddingMultiLinestringWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multilinestring('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingMultiLinestringUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multilinestring('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
     public function testAddingMultiPolygon()
     {
         $blueprint = new Blueprint('test');
@@ -119,6 +211,24 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertEquals(1, count($statements));
         $this->assertContains('GEOMETRY(MULTIPOLYGON, 27700)', $statements[0]);
+    }
+
+    public function testAddingMultiPolygonWrongSrid()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multipolygon('foo', 'GEOGRAPHY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
+    }
+
+    public function testAddingMultiPolygonUnsupported()
+    {
+        $this->setExpectedException(UnsupportedGeomtypeException::class);
+        $blueprint = new Blueprint('test');
+        $blueprint->multipolygon('foo', 'UNSUPPORTED_ENTRY', 27700);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertEquals(1, count($statements));
     }
 
     public function testAddingGeography()


### PR DESCRIPTION
This PR is based on #35 

Additionally I fixed a broken test and added a new exception (if an unsupported geomtype or illegal srid is given). Based on @phaza s comments I tried to fix the models, but could not figure out what exactly needs to be fixed.
To check what's wrong I created a model (`Location`) based on the example and tried to set it's column `location3` (which is type geometry) to `$location->location3 = new Point(37.422009, -122.084047);`. But this throws an error, because in the [PostgisTrait.php](https://github.com/v1r0x/laravel-postgis/blob/master/src/Eloquent/PostgisTrait.php#L27) file it uses `ST_GeogFromText` if the following check is true `if ($value instanceof GeometryInterface && ! $value instanceof GeometryCollection)`. My idea was to also check the `geomtype` parameter which is added in the [Blueprint.php](https://github.com/v1r0x/laravel-postgis/blob/master/src/Schema/Blueprint.php#L11). Unfortunately I couldn't find a method to perform this check. Could anyone confirm that this is the correct idea or help me what to do ( @phaza @njbarrett ) ? Thanks!