### PR TITLE
Enable/Disable Postgis without a table

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -15,4 +15,28 @@ class Builder extends \Bosnadev\Database\Schema\Builder
     {
         return new Blueprint($table, $callback);
     }
+
+    /**
+     * Enable foreign key constraints.
+     *
+     * @return bool
+     */
+    public function enablePostgis()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileEnablePostgis()
+        );
+    }
+
+    /**
+     * Disable foreign key constraints.
+     *
+     * @return bool
+     */
+    public function disablePostgis()
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDisablePostgis()
+        );
+    }
 }

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -100,11 +100,9 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to create the postgis extension
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
      * @return string
      */
-    public function compileEnablePostgis(Blueprint $blueprint, Fluent $command)
+    public function compileEnablePostgis()
     {
         return 'CREATE EXTENSION postgis';
     }
@@ -112,11 +110,9 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to drop the postgis extension
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
      * @return string
      */
-    public function compileDisablePostgis(Blueprint $blueprint, Fluent $command)
+    public function compileDisablePostgis()
     {
         return 'DROP EXTENSION postgis';
     }


### PR DESCRIPTION
Currently, to use migrations to enable or disable Postgis requires a table:
```
Schema::create('some_table', function (Blueprint $table) {
    $table->enablePostgis();
});

```
This pull request enables the use of `Schema::enablePostgis()` and `Schema::disablePostgis()` directly on the schema which makes more sense.