### PR TITLE
Fix parsing from wkt (#74)

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -40,6 +40,7 @@ class Point extends Geometry
 
     public static function fromPair($pair)
     {
+        $pair = preg_replace('/^[a-zA-Z\(\)]+/', '', trim($pair));
         list($lng, $lat) = explode(' ', trim($pair));
 
         return new static((float)$lat, (float)$lng);

--- a/tests/Geometries/GeometryCollectionTest.php
+++ b/tests/Geometries/GeometryCollectionTest.php
@@ -15,11 +15,11 @@ class GeometryCollectionTest extends BaseTestCase
     {
         $collection = new LineString(
             [
-                new Point(0, 0),
-                new Point(0, 1),
                 new Point(1, 1),
-                new Point(1, 0),
-                new Point(0, 0)
+                new Point(1, 2),
+                new Point(2, 2),
+                new Point(2, 1),
+                new Point(1, 1)
             ]
         );
 
@@ -45,7 +45,7 @@ class GeometryCollectionTest extends BaseTestCase
     public function testToWKT()
     {
         $this->assertEquals(
-            'GEOMETRYCOLLECTION(LINESTRING(0 0,1 0,1 1,0 1,0 0),POINT(200 100))',
+            'GEOMETRYCOLLECTION(LINESTRING(1 1,2 1,2 2,1 2,1 1),POINT(200 100))',
             $this->collection->toWKT()
         );
     }
@@ -58,7 +58,7 @@ class GeometryCollectionTest extends BaseTestCase
         );
 
         $this->assertSame(
-            '{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[0,0],[1,0],[1,1],[0,1],[0,0]]},{"type":"Point","coordinates":[200,100]}]}',
+            '{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[1,1],[2,1],[2,2],[1,2],[1,1]]},{"type":"Point","coordinates":[200,100]}]}',
             json_encode($this->collection->jsonSerialize())
         );
 

--- a/tests/Geometries/GeometryTest.php
+++ b/tests/Geometries/GeometryTest.php
@@ -14,28 +14,28 @@ class GeometryTest extends BaseTestCase
     public function testGetWKTArgument()
     {
         $this->assertEquals(
-            '0 0',
-            Geometry::getWKTArgument('POINT(0 0)')
+            '1 1',
+            Geometry::getWKTArgument('POINT(1 1)')
         );
         $this->assertEquals(
-            '0 0,1 1,1 2',
-            Geometry::getWKTArgument('LINESTRING(0 0,1 1,1 2)')
+            '1 1,1 2,2 2',
+            Geometry::getWKTArgument('LINESTRING(1 1,1 2,2 2)')
         );
         $this->assertEquals(
-            '(0 0,4 0,4 4,0 4,0 0),(1 1, 2 1, 2 2, 1 2,1 1)',
-            Geometry::getWKTArgument('POLYGON((0 0,4 0,4 4,0 4,0 0),(1 1, 2 1, 2 2, 1 2,1 1))')
+            '(1 1,4 1,4 4,1 4,1 1),(1 1, 2 1, 2 2, 1 2,1 1)',
+            Geometry::getWKTArgument('POLYGON((1 1,4 1,4 4,1 4,1 1),(1 1, 2 1, 2 2, 1 2,1 1))')
         );
         $this->assertEquals(
-            '(0 0),(1 2)',
-            Geometry::getWKTArgument('MULTIPOINT((0 0),(1 2))')
+            '(1 1),(1 2)',
+            Geometry::getWKTArgument('MULTIPOINT((1 1),(1 2))')
         );
         $this->assertEquals(
-            '(0 0,1 1,1 2),(2 3,3 2,5 4)',
-            Geometry::getWKTArgument('MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4))')
+            '(1 1,1 2,2 2),(2 3,3 2,5 4)',
+            Geometry::getWKTArgument('MULTILINESTRING((1 1,1 2,2 2),(2 3,3 2,5 4))')
         );
         $this->assertEquals(
-            '((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1))',
-            Geometry::getWKTArgument('MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))')
+            '((1 1,4 1,4 4,1 4,1 1),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1))',
+            Geometry::getWKTArgument('MULTIPOLYGON(((1 1,4 1,4 4,1 4,1 1),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))')
         );
         $this->assertEquals(
             'POINT(2 3),LINESTRING(2 3,3 4)',

--- a/tests/Geometries/LineStringTest.php
+++ b/tests/Geometries/LineStringTest.php
@@ -21,7 +21,7 @@ class LineStringTest extends BaseTestCase
 
     public function testFromWKT()
     {
-        $linestring = LineString::fromWKT('LINESTRING(0 0, 1 1, 2 2)');
+        $linestring = LineString::fromWkt('LINESTRING(0 0, 1 1, 2 2)');
         $this->assertInstanceOf(LineString::class, $linestring);
 
         $this->assertEquals(3, $linestring->count());

--- a/tests/Geometries/LineStringTest.php
+++ b/tests/Geometries/LineStringTest.php
@@ -9,19 +9,19 @@ class LineStringTest extends BaseTestCase
 
     protected function setUp()
     {
-        $this->points = [new Point(0, 0), new Point(1, 1), new Point(2, 2)];
+        $this->points = [new Point(1, 1), new Point(2, 2), new Point(3, 3)];
     }
 
     public function testToWKT()
     {
         $linestring = new LineString($this->points);
 
-        $this->assertEquals('LINESTRING(0 0,1 1,2 2)', $linestring->toWKT());
+        $this->assertEquals('LINESTRING(1 1,2 2,3 3)', $linestring->toWKT());
     }
 
     public function testFromWKT()
     {
-        $linestring = LineString::fromWkt('LINESTRING(0 0, 1 1, 2 2)');
+        $linestring = LineString::fromWKT('LINESTRING(1 1, 2 2,3 3)');
         $this->assertInstanceOf(LineString::class, $linestring);
 
         $this->assertEquals(3, $linestring->count());
@@ -31,7 +31,7 @@ class LineStringTest extends BaseTestCase
     {
         $linestring = new LineString($this->points);
 
-        $this->assertEquals('0 0,1 1,2 2', (string)$linestring);
+        $this->assertEquals('1 1,2 2,3 3', (string)$linestring);
     }
 
     public function testJsonSerialize()
@@ -39,6 +39,6 @@ class LineStringTest extends BaseTestCase
         $lineString = new LineString($this->points);
 
         $this->assertInstanceOf(\GeoJson\Geometry\LineString::class, $lineString->jsonSerialize());
-        $this->assertSame('{"type":"LineString","coordinates":[[0,0],[1,1],[2,2]]}', json_encode($lineString));
+        $this->assertSame('{"type":"LineString","coordinates":[[1,1],[2,2],[3,3]]}', json_encode($lineString));
     }
 }

--- a/tests/Geometries/MultiLineStringTest.php
+++ b/tests/Geometries/MultiLineStringTest.php
@@ -8,7 +8,7 @@ class MultiLineStringTest extends BaseTestCase
 {
     public function testFromWKT()
     {
-        $multilinestring = MultiLineString::fromWKT('MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4))');
+        $multilinestring = MultiLineString::fromWKT('MULTILINESTRING((1 1,2 2,2 3),(3 4,4 3,6 5))');
         $this->assertInstanceOf(MultiLineString::class, $multilinestring);
 
         $this->assertSame(2, $multilinestring->count());
@@ -18,26 +18,26 @@ class MultiLineStringTest extends BaseTestCase
     {
         $collection = new LineString(
             [
-                new Point(0, 0),
-                new Point(0, 1),
                 new Point(1, 1),
-                new Point(1, 0),
-                new Point(0, 0)
+                new Point(1, 2),
+                new Point(2, 2),
+                new Point(2, 1),
+                new Point(1, 1)
             ]
         );
 
         $multilinestring = new MultiLineString([$collection]);
 
-        $this->assertSame('MULTILINESTRING((0 0,1 0,1 1,0 1,0 0))', $multilinestring->toWKT());
+        $this->assertSame('MULTILINESTRING((1 1,2 1,2 2,1 2,1 1))', $multilinestring->toWKT());
     }
 
     public function testJsonSerialize()
     {
-        $multilinestring = MultiLineString::fromWKT('MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4))');
+        $multilinestring = MultiLineString::fromWKT('MULTILINESTRING((1 1,2 2,2 3),(3 4,4 3,6 5))');
 
         $this->assertInstanceOf(\GeoJson\Geometry\MultiLineString::class, $multilinestring->jsonSerialize());
         $this->assertSame(
-            '{"type":"MultiLineString","coordinates":[[[0,0],[1,1],[1,2]],[[2,3],[3,2],[5,4]]]}',
+            '{"type":"MultiLineString","coordinates":[[[1,1],[2,2],[2,3]],[[3,4],[4,3],[6,5]]]}',
             json_encode($multilinestring)
         );
     }

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -7,7 +7,7 @@ class MultiPointTest extends BaseTestCase
 {
     public function testFromWKT()
     {
-        $multipoint = MultiPoint::fromWkt('MULTIPOINT((0 0),(1 0),(1 1))');
+        $multipoint = MultiPoint::fromWkt('MULTIPOINT((1 1),(2 1),(2 2))');
         $this->assertInstanceOf(MultiPoint::class, $multipoint);
 
         $this->assertEquals(3, $multipoint->count());
@@ -15,20 +15,20 @@ class MultiPointTest extends BaseTestCase
 
     public function testToWKT()
     {
-        $collection = [new Point(0, 0), new Point(0, 1), new Point(1, 1)];
+        $collection = [new Point(1, 1), new Point(1, 2), new Point(2, 2)];
 
         $multipoint = new MultiPoint($collection);
 
-        $this->assertEquals('MULTIPOINT((0 0),(1 0),(1 1))', $multipoint->toWKT());
+        $this->assertEquals('MULTIPOINT((1 1),(2 1),(2 2))', $multipoint->toWKT());
     }
 
     public function testJsonSerialize()
     {
-        $collection = [new Point(0, 0), new Point(0, 1), new Point(1, 1)];
+        $collection = [new Point(1, 1), new Point(1, 2), new Point(2, 2)];
 
         $multipoint = new MultiPoint($collection);
 
         $this->assertInstanceOf(\GeoJson\Geometry\MultiPoint::class, $multipoint->jsonSerialize());
-        $this->assertSame('{"type":"MultiPoint","coordinates":[[0,0],[1,0],[1,1]]}', json_encode($multipoint));
+        $this->assertSame('{"type":"MultiPoint","coordinates":[[1,1],[2,1],[2,2]]}', json_encode($multipoint));
     }
 }

--- a/tests/Geometries/MultiPointTest.php
+++ b/tests/Geometries/MultiPointTest.php
@@ -7,7 +7,7 @@ class MultiPointTest extends BaseTestCase
 {
     public function testFromWKT()
     {
-        $multipoint = MultiPoint::fromWKT('MULTIPOINT((0 0),(1 0),(1 1))');
+        $multipoint = MultiPoint::fromWkt('MULTIPOINT((0 0),(1 0),(1 1))');
         $this->assertInstanceOf(MultiPoint::class, $multipoint);
 
         $this->assertEquals(3, $multipoint->count());

--- a/tests/Geometries/MultiPolygonTest.php
+++ b/tests/Geometries/MultiPolygonTest.php
@@ -16,11 +16,11 @@ class MultiPolygonTest extends BaseTestCase
     {
         $collection1 = new LineString(
             [
-                new Point(0, 0),
-                new Point(0, 1),
                 new Point(1, 1),
-                new Point(1, 0),
-                new Point(0, 0)
+                new Point(1, 2),
+                new Point(2, 2),
+                new Point(2, 1),
+                new Point(1, 1)
             ]
         );
 
@@ -54,19 +54,19 @@ class MultiPolygonTest extends BaseTestCase
 
     public function testFromWKT()
     {
-        $polygon = MultiPolygon::fromWKT(
-            'MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))'
-        );
+        $wkt = 'MULTIPOLYGON(((1 1,2 1,2 2,1 2,1 1),(1 1,2 1,2 2,1 2,1 1)),((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))';
+        $polygon = MultiPolygon::fromWKT($wkt);
+        
         $this->assertInstanceOf(MultiPolygon::class, $polygon);
-
         $this->assertEquals(2, $polygon->count());
+        $this->assertEquals($wkt, $polygon->toWKT());
     }
 
 
     public function testToWKT()
     {
         $this->assertEquals(
-            'MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0),(10 10,20 10,20 20,10 20,10 10)),((100 100,200 100,200 200,100 200,100 100)))',
+            'MULTIPOLYGON(((1 1,2 1,2 2,1 2,1 1),(10 10,20 10,20 20,10 20,10 10)),((100 100,200 100,200 200,100 200,100 100)))',
             $this->multiPolygon->toWKT()
         );
     }
@@ -93,7 +93,7 @@ class MultiPolygonTest extends BaseTestCase
     {
         $this->assertInstanceOf(\GeoJson\Geometry\MultiPolygon::class, $this->multiPolygon->jsonSerialize());
         $this->assertSame(
-            '{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,1],[0,0]],[[10,10],[20,10],[20,20],[10,20],[10,10]]],[[[100,100],[200,100],[200,200],[100,200],[100,100]]]]}',
+            '{"type":"MultiPolygon","coordinates":[[[[1,1],[2,1],[2,2],[1,2],[1,1]],[[10,10],[20,10],[20,20],[10,20],[10,10]]],[[[100,100],[200,100],[200,200],[100,200],[100,100]]]]}',
             json_encode($this->multiPolygon)
         );
     }

--- a/tests/Geometries/PolygonTest.php
+++ b/tests/Geometries/PolygonTest.php
@@ -12,11 +12,11 @@ class PolygonTest extends BaseTestCase
     {
         $collection = new LineString(
             [
-                new Point(0, 0),
-                new Point(0, 1),
                 new Point(1, 1),
-                new Point(1, 0),
-                new Point(0, 0)
+                new Point(1, 2),
+                new Point(2, 2),
+                new Point(2, 1),
+                new Point(1, 1)
             ]
         );
 
@@ -26,22 +26,24 @@ class PolygonTest extends BaseTestCase
 
     public function testFromWKT()
     {
-        $polygon = Polygon::fromWKT('POLYGON((0 0,4 0,4 4,0 4,0 0),(1 1, 2 1, 2 2, 1 2,1 1))');
+        $wkt = 'POLYGON((1 1,5 1,5 5,1 5,1 1),(2 2,3 2,3 3,2 3,2 2))';
+        $polygon = Polygon::fromWKT($wkt);
         $this->assertInstanceOf(Polygon::class, $polygon);
 
         $this->assertEquals(2, $polygon->count());
+        $this->assertEquals($wkt, $polygon->toWKT());
     }
 
     public function testToWKT()
     {
-        $this->assertEquals('POLYGON((0 0,1 0,1 1,0 1,0 0))', $this->polygon->toWKT());
+        $this->assertEquals('POLYGON((1 1,2 1,2 2,1 2,1 1))', $this->polygon->toWKT());
     }
 
     public function testJsonSerialize()
     {
         $this->assertInstanceOf(\GeoJson\Geometry\Polygon::class, $this->polygon->jsonSerialize());
         $this->assertSame(
-            '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+            '{"type":"Polygon","coordinates":[[[1,1],[2,1],[2,2],[1,2],[1,1]]]}',
             json_encode($this->polygon)
         );
 


### PR DESCRIPTION
This PR closes issue #74 

It also updates tests so the geometries under test don't start with coordinate (0, 0). Fixed issue arised from the fact that first latitude in MultiPolygon (and MultiPoint) when using method `fromWKT()` was always cast to 0. Therefore tests with first coordinate (0, 0) were not able to find the problem.

It was fixed by stripping all characters or parenthesis from `Point::fromPair()` argument.