### PR TITLE
Handle locales where <? (string) 1.32  // 1,32 ?>

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -58,7 +58,7 @@ class Point extends Geometry
 
     public function __toString()
     {
-        return $this->getLng() . ' ' . $this->getLat();
+        return sprintf('%F %F', $this->getLng(), $this->getLat());
     }
 
     /**


### PR DESCRIPTION
```
setlocale(LC_ALL,'fr_FR.utf8');
(string) 1.32; // return 1,32
```

PHP's __toString on floats converts it to the user's locale.
The comma will then cause a database error.