### PR TITLE
Float formating under locale

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -38,9 +38,9 @@ class Point extends Geometry
         return self::stringifyFloat($this->getLng()) . ' ' . self::stringifyFloat($this->getLat());
     }
     
-    // normalized output among locales
     private static function stringifyFloat($float)
     {
+        // normalized output among locales
         return rtrim(rtrim(sprintf('%F', $float), '0'), '.');
     }
     

--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -35,9 +35,15 @@ class Point extends Geometry
 
     public function toPair()
     {
-        return $this->getLng() . ' ' . $this->getLat();
+        return self::stringifyFloat($this->getLng()) . ' ' . self::stringifyFloat($this->getLat());
     }
-
+    
+    // normalized output among locales
+    private static function stringifyFloat($float)
+    {
+        return rtrim(rtrim(sprintf('%F', $float), '0'), '.');
+    }
+    
     public static function fromPair($pair)
     {
         $pair = preg_replace('/^[a-zA-Z\(\)]+/', '', trim($pair));
@@ -58,7 +64,7 @@ class Point extends Geometry
 
     public function __toString()
     {
-        return $this->getLng() . ' ' . $this->getLat();
+        return $this->toPair();
     }
 
     /**

--- a/tests/Geometries/UnderLocaleTest.php
+++ b/tests/Geometries/UnderLocaleTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use Phaza\LaravelPostgis\Geometries\Point;
+use Phaza\LaravelPostgis\Geometries\MultiPoint;
+use Phaza\LaravelPostgis\Geometries\LineString;
+use Phaza\LaravelPostgis\Geometries\MultiLineString;
+use Phaza\LaravelPostgis\Geometries\Polygon;
+use Phaza\LaravelPostgis\Geometries\MultiPolygon;
+use Phaza\LaravelPostgis\Geometries\GeometryCollection;
+
+class UnderLocaleTest extends BaseTestCase
+{
+    
+    public static function setUpBeforeClass()
+    {
+        setlocale(LC_NUMERIC, 'fr_FR.utf-8');
+    }
+    
+    public static function tearDownAfterClass()
+    {
+        setlocale(LC_NUMERIC, null);
+    }
+    
+    public function setUp()
+    {
+        if(localeconv()['decimal_point'] == '.') {
+            $this->markTestSkipped('The locale is not available for testing float output formatting');
+        }
+    }
+    
+    public function testPointToWKT()
+    {
+        $point = new Point(1.5, 2.5);
+        $this->assertEquals('POINT(2.5 1.5)', $point->toWKT());
+    }
+    
+    public function testMultiPointToWKT()
+    {
+        $multipoint = new MultiPoint([new Point(1.5, 1.5), new Point(1.5, 2.5), new Point(2.5, 2.5)]);
+
+        $this->assertEquals('MULTIPOINT((1.5 1.5),(2.5 1.5),(2.5 2.5))', $multipoint->toWKT());
+    }
+    
+    public function testLineStringToWKT()
+    {
+        $linestring = new LineString([new Point(1.5, 1.5), new Point(2.5, 2.5), new Point(3.5, 3.5)]);
+
+        $this->assertEquals('LINESTRING(1.5 1.5,2.5 2.5,3.5 3.5)', $linestring->toWKT());
+    }
+
+    public function testMultiLineStringToWKT()
+    {
+        $collection = new LineString(
+            [
+                new Point(1.5, 1.5),
+                new Point(1.5, 2.5),
+                new Point(2.5, 2.5),
+                new Point(2.5, 1.5),
+                new Point(1.5, 1.5)
+            ]
+        );
+
+        $multilinestring = new MultiLineString([$collection]);
+
+        $this->assertSame('MULTILINESTRING((1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5))', $multilinestring->toWKT());
+    }
+    
+    public function testPolygonToWKT()
+    {
+        $collection = new LineString(
+            [
+                new Point(1.5, 1.5),
+                new Point(1.5, 2.5),
+                new Point(2.5, 2.5),
+                new Point(2.5, 1.5),
+                new Point(1.5, 1.5)
+            ]
+        );
+
+        $polygon = new Polygon([$collection]);
+        
+        $this->assertEquals('POLYGON((1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5))', $polygon->toWKT());
+    }
+    
+    public function testMultiPolygonToWKT()
+    {
+        $collection1 = new LineString(
+            [
+                new Point(1.5, 1.5),
+                new Point(1.5, 2.5),
+                new Point(2.5, 2.5),
+                new Point(2.5, 1.5),
+                new Point(1.5, 1.5)
+            ]
+        );
+
+        $collection2 = new LineString(
+            [
+                new Point(10.5, 10.5),
+                new Point(10.5, 20.5),
+                new Point(20.5, 20.5),
+                new Point(20.5, 10.5),
+                new Point(10.5, 10.5)
+            ]
+        );
+
+        $polygon1 = new Polygon([$collection1, $collection2]);
+
+        $collection3 = new LineString(
+            [
+                new Point(100.5, 100.5),
+                new Point(100.5, 200.5),
+                new Point(200.5, 200.5),
+                new Point(200.5, 100.5),
+                new Point(100.5, 100.5)
+            ]
+        );
+
+
+        $polygon2 = new Polygon([$collection3]);
+
+        $multiPolygon = new MultiPolygon([$polygon1, $polygon2]);
+        
+        
+        $this->assertEquals(
+            'MULTIPOLYGON(((1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5),(10.5 10.5,20.5 10.5,20.5 20.5,10.5 20.5,10.5 10.5)),((100.5 100.5,200.5 100.5,200.5 200.5,100.5 200.5,100.5 100.5)))',
+            $multiPolygon->toWKT()
+        );
+    }
+    
+    public function testGeometryCollectionToWKT()
+    {
+        $collection = new LineString(
+            [
+                new Point(1.5, 1.5),
+                new Point(1.5, 2.5),
+                new Point(2.5, 2.5),
+                new Point(2.5, 1.5),
+                new Point(1.5, 1.5)
+            ]
+        );
+
+        $point = new Point(100.5, 200.5);
+
+        $geo_collection = new GeometryCollection([$collection, $point]);
+        
+        
+        $this->assertEquals(
+            'GEOMETRYCOLLECTION(LINESTRING(1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5),POINT(200.5 100.5))',
+            $geo_collection->toWKT()
+        );
+    }
+
+
+}

--- a/tests/Geometries/UnderLocaleTest.php
+++ b/tests/Geometries/UnderLocaleTest.php
@@ -116,11 +116,9 @@ class UnderLocaleTest extends BaseTestCase
             ]
         );
 
-
         $polygon2 = new Polygon([$collection3]);
 
         $multiPolygon = new MultiPolygon([$polygon1, $polygon2]);
-        
         
         $this->assertEquals(
             'MULTIPOLYGON(((1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5),(10.5 10.5,20.5 10.5,20.5 20.5,10.5 20.5,10.5 10.5)),((100.5 100.5,200.5 100.5,200.5 200.5,100.5 200.5,100.5 100.5)))',
@@ -143,13 +141,11 @@ class UnderLocaleTest extends BaseTestCase
         $point = new Point(100.5, 200.5);
 
         $geo_collection = new GeometryCollection([$collection, $point]);
-        
-        
+
         $this->assertEquals(
             'GEOMETRYCOLLECTION(LINESTRING(1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5),POINT(200.5 100.5))',
             $geo_collection->toWKT()
         );
     }
-
 
 }


### PR DESCRIPTION
Following https://github.com/njbarrett/laravel-postgis/pull/90, here is a patch proposal to deal with float formating.
WKT is actually a string representation, but should remain independant from any locale format.

An other approcah would have been [to skip the WKT layer](https://gis.stackexchange.com/a/24487/109345) and to bind directly the float values in a prepared statement. I cannot say for now how it might be done with Eloquent (several bindings for one column).