### PR TITLE
Add geometry update support

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -9,7 +9,8 @@ class Builder extends EloquentBuilder
     {
         foreach ($values as $key => &$value) {
             if ($value instanceof GeometryInterface) {
-                $value = $this->asWKT($value);
+                $attrs = $this->getPostgisType($key);
+                $value = $this->asWKT($value, $attrs);
             }
         }
 
@@ -21,12 +22,13 @@ class Builder extends EloquentBuilder
         return $this->getModel()->getPostgisFields();
     }
 
-
-    protected function asWKT(GeometryInterface $geometry)
+    protected function getPostgisType($key)
     {
-        return $this->getQuery()->raw(
-          sprintf("%s.ST_GeogFromText('%s')", function_exists('config') ? config('postgis.schema') : 'public', $geometry->toWKT())
-        );
+        return $this->getModel()->getPostgisType($key);
+    }
 
+    protected function asWKT(GeometryInterface $geometry, $attrs)
+    {
+        return $this->getModel()->asWKT($geometry, $attrs);
     }
 }

--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -36,7 +36,7 @@ trait PostgisTrait
                 function_exists('config') ? config('postgis.schema') : 'public', $geometry->toWKT(), $srid));
     }
 
-    protected function asWKT(GeometryInterface $geometry, $attrs)
+    public function asWKT(GeometryInterface $geometry, $attrs)
     {
         switch (strtoupper($attrs['geomtype'])) {
             case 'GEOMETRY':


### PR DESCRIPTION
Unfortunately, I still didn't find a way to support update on _multiple_ models, as I cannot access `getPostgisType()` from a bulk `Builder`. However, I was able to add support to single model update.

Example:

```php
$model = PostgisModel::find($id)
$model->point = new Point($x, $y);
$model->save();
```

Tests are passing, please let me know if something is missing.

Fixes #100 