### PR TITLE
Add 3D coordinates

### DIFF
--- a/src/Geometries/Factory.php
+++ b/src/Geometries/Factory.php
@@ -3,7 +3,7 @@
 class Factory implements \GeoIO\Factory {
     public function createPoint( $dimension, array $coordinates, $srid = null )
     {
-        return new Point( $coordinates['y'], $coordinates['x'] );
+        return new Point( $coordinates['y'], $coordinates['x'], isset($coordinates['z']) ? $coordinates['z'] : null );
     }
 
     public function createLineString( $dimension, array $points, $srid = null )

--- a/src/Geometries/Geometry.php
+++ b/src/Geometries/Geometry.php
@@ -30,16 +30,28 @@ abstract class Geometry implements GeometryInterface, \JsonSerializable
 
         switch (strtoupper($type)) {
             case 'POINT':
+            case 'POINTZ':
+            case 'POINT Z':
                 return Point::class;
             case 'LINESTRING':
+            case 'LINESTRINGZ':
+            case 'LINESTRING Z':
                 return LineString::class;
             case 'POLYGON':
+            case 'POLYGONZ':
+            case 'POLYGON Z':
                 return Polygon::class;
             case 'MULTIPOINT':
+            case 'MULTIPOINTZ':
+            case 'MULTIPOINT Z':
                 return MultiPoint::class;
             case 'MULTILINESTRING':
+            case 'MULTILINESTRINGZ':
+            case 'MULTILINESTRING Z':
                 return MultiLineString::class;
             case 'MULTIPOLYGON':
+            case 'MULTIPOLYGONZ':
+            case 'MULTIPOLYGON Z':
                 return MultiPolygon::class;
             case 'GEOMETRYCOLLECTION':
                 return GeometryCollection::class;

--- a/src/Geometries/LineString.php
+++ b/src/Geometries/LineString.php
@@ -2,9 +2,17 @@
 
 class LineString extends PointCollection implements GeometryInterface
 {
+    public function is3d()
+    {
+        if(count($this->points) === 0) return false;
+        return $this->points[0]->is3d();
+    }
+
     public function toWKT()
     {
-        return sprintf('LINESTRING(%s)', $this->toPairList());
+        $wktType = 'LINESTRING';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', $wktType, $this->toPairList());
     }
 
     public static function fromWKT($wkt)

--- a/src/Geometries/MultiLineString.php
+++ b/src/Geometries/MultiLineString.php
@@ -35,9 +35,17 @@ class MultiLineString extends Geometry implements Countable
         return $this->linestrings;
     }
 
+    public function is3d()
+    {
+        if(count($this->linestrings) === 0) return false;
+        return $this->linestrings[0]->is3d();
+    }
+
     public function toWKT()
     {
-        return sprintf('MULTILINESTRING(%s)', (string)$this);
+        $wktType = 'MULTILINESTRING';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', $wktType, (string)$this);
     }
 
     public static function fromString($wktArgument)

--- a/src/Geometries/MultiPoint.php
+++ b/src/Geometries/MultiPoint.php
@@ -2,9 +2,17 @@
 
 class MultiPoint extends PointCollection implements GeometryInterface, \JsonSerializable
 {
+    public function is3d()
+    {
+        if(count($this->points) === 0) return false;
+        return $this->points[0]->is3d();
+    }
+    
     public function toWKT()
     {
-        return sprintf('MULTIPOINT(%s)', (string)$this);
+        $wktType = 'MULTIPOINT';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', $wktType, (string)$this);
     }
 
     public static function fromWKT($wkt)

--- a/src/Geometries/MultiPolygon.php
+++ b/src/Geometries/MultiPolygon.php
@@ -25,9 +25,17 @@ class MultiPolygon extends Geometry implements Countable
         $this->polygons = $polygons;
     }
 
+    public function is3d()
+    {
+        if(count($this->polygons) === 0) return false;
+        return $this->polygons[0]->is3d();
+    }
+
     public function toWKT()
     {
-        return sprintf('MULTIPOLYGON(%s)', (string) $this);
+        $wktType = 'MULTIPOLYGON';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', (string) $this);
     }
 
     public function __toString()

--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -6,11 +6,13 @@ class Point extends Geometry
 {
     protected $lat;
     protected $lng;
+    protected $alt;
 
-    public function __construct($lat, $lng)
+    public function __construct($lat, $lng, $alt = null)
     {
         $this->lat = (float)$lat;
         $this->lng = (float)$lng;
+        $this->alt = isset($alt) ? (float)$alt : null;
     }
 
     public function getLat()
@@ -33,28 +35,54 @@ class Point extends Geometry
         $this->lng = (float)$lng;
     }
 
+    public function getAlt()
+    {
+        return $this->alt;
+    }
+
+    public function setLng($alt)
+    {
+        $this->alt = (float)$alt;
+    }
+
+    public function is3d()
+    {
+        return isset($this->alt);
+    }
+
     public function toPair()
     {
-        return self::stringifyFloat($this->getLng()) . ' ' . self::stringifyFloat($this->getLat());
+        $pair = self::stringifyFloat($this->getLng()) . ' ' . self::stringifyFloat($this->getLat());
+        if($this->is3d()) {
+            $pair .= ' ' . self::stringifyFloat($this->getAlt());
+        }
+        return $pair;
     }
-    
+
     private static function stringifyFloat($float)
     {
         // normalized output among locales
         return rtrim(rtrim(sprintf('%F', $float), '0'), '.');
     }
-    
+
     public static function fromPair($pair)
     {
         $pair = preg_replace('/^[a-zA-Z\(\)]+/', '', trim($pair));
-        list($lng, $lat) = explode(' ', trim($pair));
+        $splits = explode(' ', trim($pair));
+        $lng = $splits[0];
+        $lat = $splits[1];
+        if(count($splits) > 2) {
+            $alt = $splits[2];
+        }
 
-        return new static((float)$lat, (float)$lng);
+        return new static((float)$lat, (float)$lng, isset($alt) ? (float)$alt : null);
     }
 
     public function toWKT()
     {
-        return sprintf('POINT(%s)', (string)$this);
+        $wktType = 'POINT';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', $wktType, (string)$this);
     }
 
     public static function fromString($wktArgument)
@@ -74,6 +102,8 @@ class Point extends Geometry
      */
     public function jsonSerialize()
     {
-        return new \GeoJson\Geometry\Point([$this->getLng(), $this->getLat()]);
+        $position = [$this->getLng(), $this->getLat()];
+        if($this->is3d()) $position[] = $this->getAlt();
+        return new \GeoJson\Geometry\Point($position);
     }
 }

--- a/src/Geometries/Polygon.php
+++ b/src/Geometries/Polygon.php
@@ -4,10 +4,17 @@ use Countable;
 
 class Polygon extends MultiLineString implements Countable
 {
+    public function is3d()
+    {
+        if(count($this->linestrings) === 0) return false;
+        return $this->linestrings[0]->is3d();
+    }
 
     public function toWKT()
     {
-        return sprintf('POLYGON(%s)', (string)$this);
+        $wktType = 'POLYGON';
+        if($this->is3d()) $wktType .= ' Z';
+        return sprintf('%s(%s)', $wktType, (string)$this);
     }
 
     /**


### PR DESCRIPTION
Fix #18 

I (hopefully) added a third dimension as optional paramter to all neccessary constructors/create functions. In functions that return the content have a 3d check as well.
The 3d check is implemented as `is3d()` which does a simple check on the first element in the geometry (e.g. first LineString in Polygon or first Polygon in MultiPolygon, ...). I don't know if there is a better check. Any idea/suggestion is much appreciated :)

cc @njbarrett 